### PR TITLE
chore: move org, update license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.1.8
+* Move repo to OxiBUS GitHub organization
+* License change to MIT or Apache 2.0
+
 ## 0.1.7
 * Fixes compile error on older `rustc` versions (e.g. 1.84.x) where the doc-string formatting would hit `error[E0716]: temporary value dropped while borrowed`, so a let-binding is used to work around this (the latest compilers know that this was a valid use-case).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "dbc-data"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = ["Michael Fairman <mfairman@tegimeki.com>"]
 readme = "README.md"
 description = "Derive macro for CAN DBC code generation"
-repository = "https://gitlab.com/mfairman/dbc-data"
+repository = "https://github.com/oxibus/dbc-data"
 keywords = ["can", "automotive", "ecu", "no-std"]
-license = "MIT"
+license = "MIT OR Apache-2.0"
 
 
 [lib]


### PR DESCRIPTION
Changes the repo to point to its new home in the `OxiBUS` organization, and update the license to be dual MIT/Apache.

Bumps the release version to 0.1.8