### PR TITLE
chore: release v0.1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbc-data"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = ["Michael Fairman <mfairman@tegimeki.com>"]
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `dbc-data`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## 0.1.8

* Move repo to OxiBUS GitHub organization
* License change to MIT or Apache 2.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).